### PR TITLE
perf: split vendor chunk to improve load performance

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -60,7 +60,32 @@ module.exports = {
                     threshold: 10240,
                     minRatio: 0.8,
                 })
-            ]
+            ],
+            optimization: {
+                splitChunks: {
+                    chunks: 'all',
+                    cacheGroups: {
+                        echarts: {
+                            name: 'chunk-echarts',
+                            test: /[\\/]node_modules[\\/](echarts|zrender)[\\/]/,
+                            priority: 20,
+                            chunks: 'all'
+                        },
+                        vue: {
+                            name: 'chunk-vue',
+                            test: /[\\/]node_modules[\\/](vue|vue-router|vuex)[\\/]/,
+                            priority: 15,
+                            chunks: 'all'
+                        },
+                        vendors: {
+                            name: 'chunk-vendors',
+                            test: /[\\/]node_modules[\\/]/,
+                            priority: 10,
+                            chunks: 'all'
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Split `chunk-vendors.js` (493KB) into three separate chunks using webpack `splitChunks`
- `chunk-echarts` — isolates echarts + zrender (~350KB), the largest dependency
- `chunk-vue` — isolates vue core (~30KB)
- `chunk-vendors` — remaining third-party libraries (~100KB)

## Why

The original single vendor bundle prevented effective long-term caching. Echarts rarely changes, so isolating it means users only re-download it when echarts itself is updated — not on every app deployment.

## Test plan

- [ ] Run `npm run build` and verify three chunk files appear under `dist/js/`
- [ ] Confirm the app loads correctly in the browser
- [ ] Check network tab: chunks load in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved application bundle optimization through better code splitting and caching of vendor dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->