### PR TITLE
feat: add cool ASCII art banner in browser console

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,27 @@ import axios from "./util/axiosTool"
 import qs from 'qs'
 import App from './page/index.vue'
 import './assets/css/style.css'
+
+console.log(
+  '\n' +
+  '%c ██╗     ██╗     ██╗      ██████╗ ███╗   ███╗██╗  ██╗ \n' +
+  '%c ██║     ██║     ██║     ██╔═══██╗████╗ ████║██║  ██║ \n' +
+  '%c ██║     ██║     ██║     ██║   ██║██╔████╔██║███████║ \n' +
+  '%c ██║     ██║     ██║     ██║   ██║██║╚██╔╝██║██╔══██║ \n' +
+  '%c ███████╗███████╗███████╗╚██████╔╝██║ ╚═╝ ██║██║  ██║ \n' +
+  '%c ╚══════╝╚══════╝╚══════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝  ╚═╝ \n' +
+  '\n' +
+  '%c  ⚡  Welcome to LLLOMH · Real-Time Position Monitor  ⚡  \n' +
+  '%c  ✦  Author: lllomh · lllomh@qq.com                  ✦  \n',
+  'color:#00fff7;font-weight:bold;',
+  'color:#00fff7;font-weight:bold;',
+  'color:#00d4ff;font-weight:bold;',
+  'color:#00d4ff;font-weight:bold;',
+  'color:#0099ff;font-weight:bold;',
+  'color:#0066ff;font-weight:bold;',
+  'background:linear-gradient(90deg,#00fff7,#0066ff);color:#fff;font-weight:bold;padding:4px 12px;border-radius:4px;',
+  'color:#888;font-style:italic;',
+)
 Vue.config.productionTip = false
 Vue.prototype.$qs = qs
 Vue.prototype.axios = axios


### PR DESCRIPTION
## Summary

- Add a styled LLLOMH ASCII art banner that prints to the browser console on app load
- Uses box-drawing characters (`█ ╗ ╚ ═`) to render the `LLLOMH` logo
- Gradient color scheme from cyan `#00fff7` → blue `#0066ff`, each row colored independently via `%c`
- Includes a highlighted welcome line and author info

## Preview

```
 ██╗     ██╗     ██╗      ██████╗ ███╗   ███╗██╗  ██╗
 ██║     ██║     ██║     ██╔═══██╗████╗ ████║██║  ██║
 ██║     ██║     ██║     ██║   ██║██╔████╔██║███████║
 ██║     ██║     ██║     ██║   ██║██║╚██╔╝██║██╔══██║
 ███████╗███████╗███████╗╚██████╔╝██║ ╚═╝ ██║██║  ██║
 ╚══════╝╚══════╝╚══════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝  ╚═╝

  ⚡  Welcome to LLLOMH · Real-Time Position Monitor  ⚡
  ✦  Author: lllomh · lllomh@qq.com                  ✦
```

## Test plan

- [ ] Run `npm run serve` and open the browser console
- [ ] Verify the ASCII banner renders with gradient colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)